### PR TITLE
Send logged in user information to sentry when enabled in config

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ sentryLogger:
   directory: null # string|null: Where to store log files ? default is Debugger::$logDirectory, null to disable
   email: null # string|null :Where to send email notifications ? default is Debugger::$email, null to disable
   options: [release: YOUR_RELEASE] # array :All options supported by getsentry/raven-php
+  context:
+    user: true # Send logged in user information
 ```
 List of all confuration options for [getsentry/raven-php](https://github.com/getsentry/raven-php#configuration)
 

--- a/src/DI/SentryLoggerExtension.php
+++ b/src/DI/SentryLoggerExtension.php
@@ -93,6 +93,15 @@ class SentryLoggerExtension extends CompilerExtension
 				$config['options']
 			)
 		);
+
+		if (isset($config['context']['user']) && isset($config['context']['user']))
+		{
+			$init->addBody(
+				'$user = $this->getService(?);'.
+				'if ($user->isLoggedIn()) { $sentryLogger->setUserContext($user->getId(), \'\', (array) $user->getIdentity()); }',
+				['user']
+			);
+		}
 	}
 
 

--- a/src/SentryLogger.php
+++ b/src/SentryLogger.php
@@ -88,6 +88,20 @@ class SentryLogger extends Logger
     }
   }
 
+  /**
+   * Set logged in user into raven context
+   * 
+   * @param null $userId
+   * @param null $email
+   * @param array|NULL $data
+   * 
+   * @return null
+   */
+  public function setUserContext($userId = NULL, $email = NULL, array $data = NULL)
+  {
+    $this->raven->set_user_data($userId, $email, $data);
+  }
+
   public function log($message, $priority = self::INFO)
   {
     if ($this->enabled)


### PR DESCRIPTION
Config option to send currently logged in user information as Sentry context.
