### PR TITLE
change array construct to PHP version <= 5.3

### DIFF
--- a/src/DI/SentryLoggerExtension.php
+++ b/src/DI/SentryLoggerExtension.php
@@ -51,7 +51,6 @@
 
 namespace Salamek\RavenNette\DI;
 
-use Salamek\RavenNette\SentryLogger;
 use Nette\DI\CompilerExtension;
 use Nette\PhpGenerator\ClassType;
 use Nette\Utils\Validators;
@@ -74,7 +73,7 @@ class SentryLoggerExtension extends CompilerExtension
         $defaults['inDebug'] = false;
         $defaults['directory'] = Debugger::$logDirectory;
         $defaults['email'] = Debugger::$email;
-        $defaults['options'] = [];
+        $defaults['options'] = array();
 
         $config = $this->getConfig($defaults);
 
@@ -90,12 +89,12 @@ class SentryLoggerExtension extends CompilerExtension
         }
 
         $init->addBody(
-            '$sentryLogger = new ' . SentryLogger::class . '(?, ?, ?, ?, ?, ?);' .
-            Debugger::class . '::$onFatalError[] = function($e) use($sentryLogger)' .
+            '$sentryLogger = new Salamek\RavenNette\SentryLogger(?, ?, ?, ?, ?, ?);' .
+            'Tracy\Debugger::$onFatalError[] = function($e) use($sentryLogger)' .
             '{' .
             '  $sentryLogger->onFatalError($e);' .
             '};' .
-            Debugger::class . '::setLogger($sentryLogger);',
+            'Tracy\Debugger::setLogger($sentryLogger);',
             array(
                 $config['dsn'],
                 $config['inDebug'],
@@ -110,7 +109,7 @@ class SentryLoggerExtension extends CompilerExtension
             $init->addBody(
                 '$user = $this->getService(?);' .
                 'if ($user->isLoggedIn()) { $sentryLogger->setUserContext($user->getId(), \'\', (array) $user->getIdentity()); }',
-                ['user']
+                array('user')
             );
         }
     }

--- a/src/SentryLogger.php
+++ b/src/SentryLogger.php
@@ -76,10 +76,11 @@ class SentryLogger extends Logger
      * @param bool $autoWire
      * @param array $options
      */
-    public function __construct($dsn, $inDebug = false, $directory = null, $email = null, $autoWire = true, $options = [])
+    public function __construct($dsn, $inDebug = false, $directory = null, $email = null, $autoWire = true, $options = array())
     {
         // Compability with nette 2.2.0, Tracy\Logger has no __construct in 2.2.0
-        if((new \ReflectionClass('Tracy\Logger'))->getConstructor())
+        $tracyLogger = new \ReflectionClass('Tracy\Logger');
+        if($tracyLogger->getConstructor())
         {
             parent::__construct($directory, $email, Debugger::getBlueScreen());
         }


### PR DESCRIPTION
In composer.json is "php": ">=5.3.0"
I tried it on our legacy application and It doesn`t work, because there was PHP 5.4 array syntax.